### PR TITLE
fixup include paths for 4.24 (DefaultBuildSettings changed)

### DIFF
--- a/Source/LoadingScreen/Private/LoadingScreenSettings.h
+++ b/Source/LoadingScreen/Private/LoadingScreenSettings.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Fonts/SlateFontInfo.h"
-#include "SScaleBox.h"
+#include "Widgets/Layout/SScaleBox.h"
 #include "MoviePlayer.h"
 #include "Engine/DeveloperSettings.h"
 

--- a/Source/LoadingScreen/Private/SSimpleLoadingScreen.h
+++ b/Source/LoadingScreen/Private/SSimpleLoadingScreen.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "SCompoundWidget.h"
+#include "Widgets/SCompoundWidget.h"
 #include "LoadingScreenSettings.h"
 
 class FDeferredCleanupSlateBrush;

--- a/Source/LoadingScreen/Public/ILoadingScreenModule.h
+++ b/Source/LoadingScreen/Public/ILoadingScreenModule.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 /**
  * The public interface to this module


### PR DESCRIPTION
DefaultBuildSettings changed in 4.24.2 and doesn't include many of the subdirectories that were previously included.

This PR just fixes up some of the paths; everything else continues to function.